### PR TITLE
Switch to checkmate for argument checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Authors@R: c(person(given = "Jairson", family ="Rodrigues", role = c("aut", "cre
 Maintainer: Jairson Rodrigues <jairson.rodrigues@univasf.edu.br>
 Description: An evolutionary approach to performing hard partitional clustering. The algorithm uses genetic operators guided by information about the quality of individual partitions. The method looks for the best barycenters/centroids configuration (encoded as real-value) to maximize or minimize one of the given clustering validation criteria: Silhouette, Dunn Index, C-Index or Calinski-Harabasz Index. As many other clustering algorithms, 'gama' asks for k: a fixed a priori established number of partitions. If the user does not know the best value for k, the algorithm estimates it by using one of two user-specified options: minimum or broad. The first method uses an approximation of the second derivative of a set of points to automatically detect the maximum curvature (the 'elbow') in the within-cluster sum of squares error (WCSSE) graph. The second method estimates the best k value through majority voting of 24 indices. One of the major advantages of 'gama' is to introduce a bias to detect partitions which attend a particular criterion. References: Scrucca, L. (2013) <doi:10.18637/jss.v053.i04>; CHARRAD, Malika et al. (2014) <doi:10.18637/jss.v061.i06>; Tsagris M, Papadakis M. (2018) <doi:10.7287/peerj.preprints.26605v1>; Kaufman, L., & Rousseeuw, P. (1990, ISBN:0-47 1-73578-7).
 Imports: 
-  ArgumentCheck,
+  checkmate,
   cluster, 
   clusterCrit, 
   NbClust, 

--- a/R/bestk.R
+++ b/R/bestk.R
@@ -3,28 +3,17 @@
 gama.how.many.k <- function(dataset = NULL, method = "minimal") {
 
     # --- arguments validation --- #
-    Check <- ArgumentCheck::newArgCheck()
+    Check <- checkmate::makeAssertCollection()
 
-    if (is.null(dataset))
-      ArgumentCheck::addError(
-        msg = "'dataset' can not be NULL",
-        argcheck = Check
-      )
-
-    if (class(dataset) != 'data.frame')
-      ArgumentCheck::addError(
-        msg = "'dataset' must be a data.frame object.",
-        argcheck = Check
-      )
-
-    if (!(method %in% c('minimal', 'broad')))
-      ArgumentCheck::addError(
-        msg = "'method' must be one of the values: 'minimal' or 'broad'.",
-        argcheck = Check
-      )
-
-    ArgumentCheck::finishArgCheck(Check)
-
+    checkmate::assert_data_frame(x = dataset, 
+                                 add = Check)
+    
+    method <- checkmate::matchArg(x = method, 
+                                  choices = c("minimal", "broad"), 
+                                 add = Check))
+    
+    checkmate::reportAssertions(Check)
+    
     # --- final of arguments validation --- #
 
     best.k <- -1

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -30,59 +30,32 @@ gama <- function(dataset = NULL, k = "broad", scale = FALSE, crossover.rate = 0.
                          plot.internals = TRUE, ...) {
 
   # --- arguments validation --- #
-  Check <- ArgumentCheck::newArgCheck()
+  Check <- checkmate::makeAssertCollection()
 
-  if (is.null(dataset))
-    ArgumentCheck::addError(
-      msg = "'dataset' can not be NULL",
-      argcheck = Check)
-
-  if (class(dataset) != 'data.frame')
-    ArgumentCheck::addError(
-      msg = "'dataset' must be a data.frame object.",
-      argcheck = Check)
-
+  checkmate::assert_data_frame(x = dataset, 
+                               add = Check)
   if (is.null(k))
-    ArgumentCheck::addError(
-      msg = "'k' can not be NULL",
-      argcheck = Check)
+    Check$push("'k' can not be NULL")
 
   if (is.numeric(k)) {
     # forces k to be an integer value
     k <- as.integer(k)
 
     if (k < 2) {
-      ArgumentCheck::addError(
-        msg = "'k' must be a positive integer value greater than one (k > 1), or one of the methods to estimate it: 'minimal' or 'broad'.",
-        argcheck = Check)
+      Check$push("'k' must be a positive integer value greater than one (k > 1), or one of the methods to estimate it: 'minimal' or 'broad'.")
     }
   } else if (is.character(k)) {
     if (!(k %in% c('minimal', 'broad')))
-      ArgumentCheck::addError(
-        msg = "'k' must be a positive integer value greater than one (k > 1), or one of the methods to estimate it: 'minimal' or 'broad'.",
-        argcheck = Check)
+      Check$push("'k' must be a positive integer value greater than one (k > 1), or one of the methods to estimate it: 'minimal' or 'broad'.")
   }
 
-  if (is.null(fitness.criterion)) {
-    ArgumentCheck::addError(
-      msg = "'fitness.criterion' can not be NULL.",
-      argcheck = Check)
+  fitness.criterion <- checkmate::matchArg(x = fitness.criterion, 
+                                           choices = c('ASW', 'CH', 'CI', 'DI'))
+  
+  checkmate::assert_function(x = penalty.function, 
+                             add = Check)
 
-  } else if (!(fitness.criterion %in% c('ASW', 'CH', 'CI', 'DI'))) {
-    ArgumentCheck::addError(
-      msg = "'fitness.criterion' must be one of the criteria: 'ASW', 'CH', 'CI' or 'DI'.",
-      argcheck = Check)
-  }
-
-  if (!is.null(penalty.function)) {
-    if (class(penalty.function) != "function") {
-      ArgumentCheck::addError(
-        msg = "'penalty.function' must be a valid R function.",
-        argcheck = Check)
-    }
-  }
-
-  ArgumentCheck::finishArgCheck(Check)
+  checkmate::reportAssertions(Check)
 
   # --- final of arguments validation --- #
 

--- a/R/vis.R
+++ b/R/vis.R
@@ -3,32 +3,17 @@
 gama.plot.partitions <- function(gama.obj = NULL, view = "pca", ...) {
 
   # --- arguments validation --- #
-  Check <- ArgumentCheck::newArgCheck()
+  Check <- checkmate::makeAssertCollection()
 
-  if (is.null(gama.obj))
-    ArgumentCheck::addError(
-      msg = "'gama.obj' can not be NULL",
-      argcheck = Check
-    )
+  checkmate::assert_class(x = gama.obj, 
+                          classes = "gama", 
+                          add = Check)
 
-  if (class(gama.obj) != 'gama')
-    ArgumentCheck::addError(
-      msg = "'gama.obj' must be a gama object.",
-      argcheck = Check
-    )
+  view <- checkmate::matchArg(x = view, 
+                              choices = c('pca', 'total.sum'), 
+                              add = Check)
 
-  if (is.null(view)) {
-    ArgumentCheck::addError(
-      msg = "'view' can not be NULL",
-      argcheck = Check
-    )
-  } else if (!(view %in% c('pca', 'total.sum')))
-    ArgumentCheck::addError(
-      msg = "'view' must be etiher 'pca' or 'total.sum'.",
-      argcheck = Check
-    )
-
-  ArgumentCheck::finishArgCheck(Check)
+  checkmate::reportAssertions(Check)
 
   # --- final of arguments validation --- #
 


### PR DESCRIPTION
I noticed you are using my `ArgumentCheck` package. I thought you may be interested to know that I am not actively maintaining that package, and rarely use it myself.  The `checkmate` package is, in my opinion, far superior, actively maintained, and quite stable.  I've been using it for 5 years and have never experienced a breaking change.

I've been toying removing `ArgumentCheck` from CRAN, but haven't gone through with that decision yet.

I've adapted your code to `checkmate` in this pull request.  Please note I haven't run any tests.  My computer is tied up doing some reverse dependency checks. 